### PR TITLE
gh-115704: Improve DJBX33A hash algorithm

### DIFF
--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -168,18 +168,24 @@ _Py_HashBytes(const void *src, Py_ssize_t len)
         const unsigned char *p = src;
         hash = 5381; /* DJBX33A starts with 5381 */
 
-        switch(len) {
-            /* ((hash << 5) + hash) + *p == hash * 33 + *p */
-            case 7: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 6: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 5: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 4: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 3: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 2: hash = ((hash << 5) + hash) + *p++; _Py_FALLTHROUGH;
-            case 1: hash = ((hash << 5) + hash) + *p++; break;
-            default:
-                Py_UNREACHABLE();
+        if (len >= 4) {
+            /* 1185921 = 33^4, 35937 = 33^3, 1089 = 33^2 */
+            hash = hash * 1185921 + p[0] * 35937 + p[1] * 1089 +
+                    p[2] * 33 + p[3];
+            len -= 4;
+            p += 4;
         }
+        else if (len >= 2) {
+            if (len > 2) {
+                hash = hash * 35937 + p[0] * 1089 + p[1] * 33 + p[2];
+            }
+            else {
+		        hash = hash * 1089 + p[0] * 33 + p[1];
+            }
+	    }
+        else if (len != 0 ) {
+            hash = hash * 33 + *p;
+	    }
         hash ^= len;
         hash ^= (Py_uhash_t) _Py_HashSecret.djbx33a.suffix;
         x = (Py_hash_t)hash;


### PR DESCRIPTION
Accelerating python hash algorithm by "unoptimizing" it when using DJBX33A as hash algorithm. See Daniel Lemire's blog post: https://lemire.me/blog/2016/07/21/accelerating-php-hashing-by-unoptimizing-it/

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
